### PR TITLE
main: some minor fixes in dump and check commands

### DIFF
--- a/check_command.go
+++ b/check_command.go
@@ -1,35 +1,38 @@
 package main
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 )
 
 func Check(option CheckOption) error {
 	if option.FileName != "" {
 		err := checkFile(option.FileName, option.Verbose)
 		check(err)
-	} else {
-		if option.Directory != "" {
-			_, err := ioutil.ReadDir(option.Directory)
-			check(err)
-			err = filepath.Walk(option.Directory,
-				func(path string, info fs.FileInfo, err error) error {
-					if strings.HasSuffix(path, ".flb") {
-						err = checkFile(path, option.Verbose)
-						check(err)
-					}
-					return nil
-				})
-			check(err)
-		}
+		return nil
 	}
 
+	if option.Directory == "" {
+		return nil
+	}
+
+	err := filepath.Walk(option.Directory,
+		func(path string, info fs.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if !info.IsDir() && filepath.Ext(path) == ".flb" {
+				err = checkFile(path, option.Verbose)
+				check(err)
+			}
+			return nil
+		})
+	check(err)
 	return nil
 }
 
@@ -46,13 +49,13 @@ func checkFile(fileName string, verbose bool) error {
 		os.Exit(1)
 	}
 
-	readHeader(f, verbose)
+	if !readHeader(f, verbose) {
+		fmt.Println("Corrupted (bad header)")
+		os.Exit(1)
+	}
 	readCRC(f, verbose)
 	readPadding(f, verbose)
 	getMetadataLength(f, verbose)
-
-	err = f.Close()
-	check(err)
 
 	fmt.Println("OK")
 	return nil
@@ -67,25 +70,25 @@ func fileInfo(f *os.File, verbose bool) int64 {
 	return fileInformation.Size()
 }
 
-func readHeader(f *os.File, verbose bool) ([]byte, int) {
-	bytesRead, content := readNBytesFromFile(f, HeaderBytesQuantity)
+func readHeader(f *os.File, verbose bool) bool {
+	bytesRead := readNBytesFromFile(f, HeaderBytesQuantity)
 	if verbose {
-		fmt.Printf("%d bytes from header: %s\n", content, string(bytesRead[:content]))
+		fmt.Printf("%d bytes from header: % X\n", len(bytesRead), bytesRead)
 	}
-	return bytesRead, content
+	return bytes.Equal(bytesRead, ExpectedHeader)
 }
 
 func readCRC(f *os.File, verbose bool) {
-	bytesRead, content := readNBytesFromFile(f, CRCBytesQuantity)
+	bytesRead := readNBytesFromFile(f, CRCBytesQuantity)
 	if verbose {
-		fmt.Printf("%d bytes from CRC: %s\n", content, string(bytesRead[:content]))
+		fmt.Printf("%d bytes from CRC: % X\n", len(bytesRead), bytesRead)
 	}
 }
 
 func readPadding(f *os.File, verbose bool) {
-	bytesRead, content := readNBytesFromFile(f, CRCPaddingBytesQuantity)
+	bytesRead := readNBytesFromFile(f, CRCPaddingBytesQuantity)
 	if verbose {
-		fmt.Printf("%d bytes read from Padding: %s\n", content, string(bytesRead[:content]))
+		fmt.Printf("%d bytes read from Padding: % X\n", len(bytesRead), bytesRead)
 	}
 }
 
@@ -93,7 +96,7 @@ func getMetadataLength(f *os.File, verbose bool) uint16 {
 	_, err := f.Seek(MetadataStart, 0)
 	check(err)
 
-	bytesRead, _ := readNBytesFromFile(f, MetadataLengthBytesQuantity)
+	bytesRead := readNBytesFromFile(f, MetadataLengthBytesQuantity)
 	data := binary.BigEndian.Uint16(bytesRead)
 	if verbose {
 		fmt.Printf("Metadata Length: %d\n", data)
@@ -101,11 +104,11 @@ func getMetadataLength(f *os.File, verbose bool) uint16 {
 	return data
 }
 
-func readNBytesFromFile(file *os.File, bytesToRead int64) ([]byte, int) {
-	b1 := make([]byte, bytesToRead)
-	n1, err := file.Read(b1)
+func readNBytesFromFile(file *os.File, bytesToRead int64) []byte {
+	buf := make([]byte, bytesToRead)
+	_, err := io.ReadFull(file, buf)
 	check(err)
-	return b1, n1
+	return buf
 }
 
 func check(err error) {

--- a/consts.go
+++ b/consts.go
@@ -11,3 +11,5 @@ const (
 
 	MetadataStart = HeaderBytesQuantity + CRCBytesQuantity + CRCPaddingBytesQuantity
 )
+
+var ExpectedHeader = []byte{0xC1, 0x00}

--- a/dump_command.go
+++ b/dump_command.go
@@ -3,10 +3,12 @@ package main
 import "C"
 import (
 	"fmt"
-	"github.com/fluent/fluent-bit-go/output"
 	"os"
+	"sort"
 	"time"
 	"unsafe"
+
+	"github.com/fluent/fluent-bit-go/output"
 )
 
 func Dump(option DumpOption) error {
@@ -21,6 +23,8 @@ func Dump(option DumpOption) error {
 
 	f, err := os.Open(option.FileName)
 	check(err)
+	defer f.Close()
+
 	mLength := getMetadataLength(f, option.Verbose)
 
 	if mLength > 0 {
@@ -48,7 +52,8 @@ func Dump(option DumpOption) error {
 func decode(data unsafe.Pointer, length int) int {
 	decoder := output.NewDecoder(data, length)
 	if decoder == nil {
-		fmt.Errorf("dec is nil")
+		fmt.Fprintln(os.Stderr, "decoder is nil")
+		os.Exit(1)
 	}
 
 	count := 0
@@ -73,10 +78,22 @@ func decode(data unsafe.Pointer, length int) int {
 			timestamp = time.Now()
 		}
 
-		// Print record keys and values
-		fmt.Printf("[%d] [%s, {", count, timestamp.String())
+		type kv struct {
+			key string
+			val interface{}
+		}
+		entries := make([]kv, 0, len(record))
 		for k, v := range record {
-			fmt.Printf("\"%s\": %s, ", k, v)
+			entries = append(entries, kv{fmt.Sprintf("%s", k), v})
+		}
+		sort.Slice(entries, func(i, j int) bool { return entries[i].key < entries[j].key })
+
+		fmt.Printf("[%d] [%s, {", count, timestamp.String())
+		for i, e := range entries {
+			if i > 0 {
+				fmt.Print(", ")
+			}
+			fmt.Printf("\"%s\": %s", e.key, e.val)
 		}
 		fmt.Printf("}]\n")
 		count++
@@ -86,21 +103,22 @@ func decode(data unsafe.Pointer, length int) int {
 }
 
 func readUserData(f *os.File, metadataLength uint16, fileSize int64, verbose bool) []byte {
-	userDataStart := int64(FileMetaBytesQuantity - MetadataHeader + metadataLength)
+	userDataStart := int64(FileMetaBytesQuantity-MetadataHeader) + int64(metadataLength)
 	remainingBytes := fileSize - userDataStart
-	f.Seek(userDataStart, 0)
-	bytesRead, content := readNBytesFromFile(f, remainingBytes)
-	userData := bytesRead[:content]
+	_, err := f.Seek(userDataStart, 0)
+	check(err)
+	userData := readNBytesFromFile(f, remainingBytes)
 	if verbose {
-		fmt.Printf("%d bytes read from User Content: [%s]\n", content, string(userData))
+		fmt.Printf("%d bytes read from User Content: [%s]\n", len(userData), string(userData))
 	}
-	return bytesRead
+	return userData
 }
 
 func readMetadata(f *os.File, mLength uint16, verbose bool) {
-	f.Seek(4, 1)                                               //metadata headers
-	bytesRead, size := readNBytesFromFile(f, int64(mLength-4)) //metadata headers bytes are part of the metadata declared size
+	_, err := f.Seek(MetadataHeader, 1) //metadata headers
+	check(err)
+	bytesRead := readNBytesFromFile(f, int64(mLength-MetadataHeader)) //metadata headers bytes are part of the metadata declared size
 	if verbose {
-		fmt.Printf("%d bytes read from Metadata: [%s]\n", size, string(bytesRead[:size]))
+		fmt.Printf("%d bytes read from Metadata: [%s]\n", len(bytesRead), string(bytesRead))
 	}
 }


### PR DESCRIPTION
dump command:

- use io.ReadFull and propagate ignored errors
- sort record keys and exit on nil decoder
- drop deprecated ioutil and use filepath.Ext

check command:

- validate header magic bytes